### PR TITLE
Type inference, yaml executable, cram tests

### DIFF
--- a/YaML/dune
+++ b/YaML/dune
@@ -17,5 +17,6 @@
   ./tests/factorial.ya
   ./tests/fibonacci.ya
   ./tests/combinators.ya
+  ./tests/occurs-check-disable.ya
   ./yaml.exe
   %{bin:yaml}))

--- a/YaML/dune
+++ b/YaML/dune
@@ -13,4 +13,4 @@
  (libraries YaML.Lib stdio))
 
 (cram
- (deps ./yaml.exe %{bin:yaml}))
+ (deps ./tests/factorial.ya ./tests/fibonacci.ya ./yaml.exe %{bin:yaml}))

--- a/YaML/dune
+++ b/YaML/dune
@@ -1,0 +1,16 @@
+(env
+ (dev
+  (flags
+   (:standard -warn-error -A -w -3-9-32-34-58)))
+ (release
+  (flags
+   (:standard -warn-error -A -w -58))))
+
+(executable
+ (name yaml)
+ (public_name yaml)
+ (modules Yaml)
+ (libraries YaML.Lib stdio))
+
+(cram
+ (deps ./yaml.exe %{bin:yaml}))

--- a/YaML/dune
+++ b/YaML/dune
@@ -13,4 +13,9 @@
  (libraries YaML.Lib stdio))
 
 (cram
- (deps ./tests/factorial.ya ./tests/fibonacci.ya ./yaml.exe %{bin:yaml}))
+ (deps
+  ./tests/factorial.ya
+  ./tests/fibonacci.ya
+  ./tests/combinators.ya
+  ./yaml.exe
+  %{bin:yaml}))

--- a/YaML/lib/Pprinttypedtree.ml
+++ b/YaML/lib/Pprinttypedtree.ml
@@ -4,6 +4,7 @@
 
 open Typedtree
 open Base
+open Stdlib.Format
 
 let get_texpr_subst =
   let rec helper subs index = function
@@ -15,10 +16,11 @@ let get_texpr_subst =
       let subs, index = Pprinttypetree.get_ty_subs subs index typ in
       let subs, index = helper subs index e1 in
       helper subs index e2
-    | TLet (_, e, typ) | TLetRec (_, e, typ) | TFun (_, e, typ) ->
+    | TFun (_, e, typ) ->
       let subs, index = Pprinttypetree.get_ty_subs subs index typ in
       helper subs index e
-    | TIfThenElse (e1, e2, e3) ->
+    | TIfThenElse (e1, e2, e3, typ) ->
+      let subs, index = Pprinttypetree.get_ty_subs subs index typ in
       let subs, index = helper subs index e1 in
       let subs, index = helper subs index e2 in
       helper subs index e3
@@ -27,18 +29,16 @@ let get_texpr_subst =
   helper (Base.Map.empty (module Base.Int)) 0
 ;;
 
-let space ppf depth = Stdlib.Format.fprintf ppf "\n%*s" (4 * depth) ""
+let space ppf depth = fprintf ppf "\n%*s" (4 * depth) ""
 
 let pp_arg subs ppf =
   let pp_ty = Pprinttypetree.pp_ty_with_subs subs in
   function
-  | Arg (name, typ) -> Stdlib.Format.fprintf ppf "(%s: %a)" name pp_ty typ
+  | Arg (name, typ) -> fprintf ppf "(%s: %a)" name pp_ty typ
 ;;
 
 (* A monster that needs refactoring *)
-let pp_texpr ppf texpr =
-  let open Stdlib.Format in
-  let subs, _ = get_texpr_subst texpr in
+let pp_texpr_with_subs ppf depth subs texpr =
   let pp_ty = Pprinttypetree.pp_ty_with_subs (Some subs) in
   let pp_arg = pp_arg (Some subs) in
   let rec helper depth ppf =
@@ -78,21 +78,6 @@ let pp_texpr ppf texpr =
         e2
         space
         (depth - 1)
-    | TLet (name, e, typ) ->
-      fprintf
-        ppf
-        "(TLet(%a%s: %a, %a%a%a))"
-        space
-        depth
-        name
-        pp_ty
-        typ
-        space
-        depth
-        pp
-        e
-        space
-        (depth - 1)
     | TLetIn (name, e1, e2, typ) ->
       fprintf
         ppf
@@ -110,21 +95,6 @@ let pp_texpr ppf texpr =
         depth
         pp
         e2
-        space
-        (depth - 1)
-    | TLetRec (name, e, typ) ->
-      fprintf
-        ppf
-        "(TLetRec(%a%s: %a, %a%a%a))"
-        space
-        depth
-        name
-        pp_ty
-        typ
-        space
-        depth
-        pp
-        e
         space
         (depth - 1)
     | TLetRecIn (name, e1, e2, typ) ->
@@ -162,12 +132,14 @@ let pp_texpr ppf texpr =
         e
         space
         (depth - 1)
-    | TIfThenElse (i, t, e) ->
+    | TIfThenElse (i, t, e, typ) ->
       fprintf
         ppf
-        "(TIfThenElse(%a%a, %a%a, %a%a%a))"
+        "(TIfThenElse(%a : %a%a, %a%a, %a%a%a))"
         space
         depth
+        pp_ty
+        typ
         pp
         i
         space
@@ -182,5 +154,43 @@ let pp_texpr ppf texpr =
         (depth - 1)
     | TConst (c, typ) -> fprintf ppf "(TConst(%s: %a))" (Ast.show_const c) pp_ty typ
   in
-  helper 1 ppf texpr
+  helper depth ppf texpr
+;;
+
+let pp_texpr ppf texpr =
+  let subs, _ = get_texpr_subst texpr in
+  pp_texpr_with_subs ppf 1 subs
+;;
+
+let show_binding = function
+  | TLetRec _ -> "TLetRec"
+  | TLet _ -> "TLet"
+;;
+
+let pp_tbinding ppf = function
+  | (TLetRec (name, e, typ) | TLet (name, e, typ)) as binding ->
+    let subs, _ = get_texpr_subst e in
+    let pp_ty = Pprinttypetree.pp_ty_with_subs (Some subs) in
+    let pp_expr ppf = pp_texpr_with_subs ppf 2 subs in
+    fprintf
+      ppf
+      "(%s(%a%s: %a, %a%a%a))"
+      (show_binding binding)
+      space
+      1
+      name
+      pp_ty
+      typ
+      space
+      1
+      pp_expr
+      e
+      space
+      1
+;;
+
+let pp_statements =
+  pp_print_list
+    ~pp_sep:(fun ppf _ -> fprintf ppf ";")
+    (fun ppf binding -> pp_tbinding ppf binding)
 ;;

--- a/YaML/lib/Pprinttypedtree.ml
+++ b/YaML/lib/Pprinttypedtree.ml
@@ -193,8 +193,8 @@ let pp_tbinding_complete ppf = function
 
 let pp_tbinding_brief ppf = function
   | TLetRec (name, _, typ) | TLet (name, _, typ) ->
-    let pp_ty = Pprinttypetree.pp_ty_with_subs None in
-    fprintf ppf "%s %a" name pp_ty typ
+    let pp_ty = Pprinttypetree.pp_ty in
+    fprintf ppf "%s: %a" name pp_ty typ
 ;;
 
 let pp_tbinding = pp_tbinding_complete

--- a/YaML/lib/Pprinttypedtree.ml
+++ b/YaML/lib/Pprinttypedtree.ml
@@ -139,11 +139,11 @@ let pp_texpr_with_subs ppf depth subs texpr =
     | TIfThenElse (i, t, e, typ) ->
       fprintf
         ppf
-        "(TIfThenElse(%a : %a%a, %a%a, %a%a%a))"
-        space
-        depth
+        "(TIfThenElse: %a%a(%a, %a%a, %a%a%a))"
         pp_ty
         typ
+        space
+        depth
         pp
         i
         space
@@ -178,7 +178,7 @@ let pp_tbinding_complete ppf = function
     let pp_expr ppf = pp_texpr_with_subs ppf 2 subs in
     fprintf
       ppf
-      "(%s(%a%s: %a, %a%a%a))"
+      "(%s(%a%s: %a, %a%a\n))"
       (show_binding binding)
       space
       1
@@ -189,8 +189,6 @@ let pp_tbinding_complete ppf = function
       1
       pp_expr
       e
-      space
-      1
 ;;
 
 let pp_tbinding_brief ppf = function

--- a/YaML/lib/Pprinttypedtree.mli
+++ b/YaML/lib/Pprinttypedtree.mli
@@ -2,5 +2,11 @@
 
 (** SPDX-License-Identifier: LGPL-2.1-or-later *)
 
-(** Pretty printer for typed expesstion *)
+(** Pretty printer for typed expession *)
 val pp_texpr : Format.formatter -> Typedtree.texpr -> unit
+
+(** Pretty printer for typed expession *)
+val pp_tbinding : Format.formatter -> Typedtree.tbinding -> unit
+
+(** Pretty printer for typed statements *)
+val pp_statements : Format.formatter -> Typedtree.tstatements -> unit

--- a/YaML/lib/Pprinttypedtree.mli
+++ b/YaML/lib/Pprinttypedtree.mli
@@ -2,6 +2,10 @@
 
 (** SPDX-License-Identifier: LGPL-2.1-or-later *)
 
+type mode =
+  | Brief
+  | Complete
+
 (** Pretty printer for typed expession *)
 val pp_texpr : Format.formatter -> Typedtree.texpr -> unit
 
@@ -9,4 +13,9 @@ val pp_texpr : Format.formatter -> Typedtree.texpr -> unit
 val pp_tbinding : Format.formatter -> Typedtree.tbinding -> unit
 
 (** Pretty printer for typed statements *)
-val pp_statements : Format.formatter -> Typedtree.tstatements -> unit
+val pp_statements
+  :  (unit, Format.formatter, unit) format
+  -> mode
+  -> Format.formatter
+  -> Typedtree.tbinding list
+  -> unit

--- a/YaML/lib/inferencer.ml
+++ b/YaML/lib/inferencer.ml
@@ -1000,8 +1000,8 @@ let%expect_test _ =
   in
   [%expect
     {|
-    (TIfThenElse(
-        (TConst((CBool true): bool)),
+    (TIfThenElse: int
+        ((TConst((CBool true): bool)),
         (TConst((CInt 4): int)),
         (TConst((CInt 5): int))
     ))
@@ -1018,8 +1018,8 @@ let%expect_test _ =
   in
   [%expect
     {|
-    (TIfThenElse(
-        (TConst((CBool true): bool)),
+    (TIfThenElse: bool
+        ((TConst((CBool true): bool)),
         (TConst((CBool true): bool)),
         (TConst((CBool false): bool))
     ))
@@ -1329,8 +1329,8 @@ let%expect_test _ =
                 helper: (int -> int),
                 (TFun: (int -> int) (
                     (x: int),
-                    (TIfThenElse(
-                        (Eq: (int -> (int -> bool)) (
+                    (TIfThenElse: int
+                        ((Eq: (int -> (int -> bool)) (
                             (x: int),
                             (TConst((CInt 1): int))
                         )),
@@ -1383,8 +1383,8 @@ let%expect_test _ =
         fact: (int -> int),
         (TFun: (int -> int) (
             (n: int),
-            (TIfThenElse(
-                (Eq: (int -> (int -> bool)) (
+            (TIfThenElse: int
+                ((Eq: (int -> (int -> bool)) (
                     (n: int),
                     (TConst((CInt 1): int))
                 )),
@@ -1448,8 +1448,8 @@ let%expect_test _ =
                     (n: int),
                     (TFun: (int -> int) (
                         (acc: int),
-                        (TIfThenElse(
-                            (Lt: (int -> (int -> bool)) (
+                        (TIfThenElse: int
+                            ((Lt: (int -> (int -> bool)) (
                                 (n: int),
                                 (TConst((CInt 1): int))
                             )),

--- a/YaML/lib/inferencer.ml
+++ b/YaML/lib/inferencer.ml
@@ -134,11 +134,18 @@ module Subst : sig
 
   val compose_all : t list -> t R.t
   val remove : t -> fresh -> t
+  (* val pp : Format.formatter -> t -> unit *)
 end = struct
   open R
   open R.Syntax
 
   type t = (fresh, ty) Map.Poly.t
+
+  (* let pp ppf subst =
+     let open Format in
+     Map.Poly.iteri subst ~f:(fun ~key ~data ->
+     fprintf ppf "'_%d -> %a@\n" key (Pprinttypetree.pp_ty_with_subs None) data)
+     ;; *)
 
   let empty = Map.Poly.empty
   let mapping k v = if Type.occurs_in k v then fail `Occurs_check else return (k, v)

--- a/YaML/lib/inferencer.ml
+++ b/YaML/lib/inferencer.ml
@@ -391,8 +391,10 @@ let infer_binding env =
   | ELetRec (name, e) ->
     let* tv = fresh_var in
     let env = TypeEnv.extend env (name, S (VarSet.empty, tv)) in
-    let* s, t, te = infer_expr env e in
-    return (s, t, tletrec name te t)
+    let* s1, t, te = infer_expr env e in
+    let* s2 = unify (Subst.apply s1 tv) t in
+    let* funal_subst = Subst.compose s1 s2 in
+    return (funal_subst, t, tletrec name te t)
 ;;
 
 let fix_typedtree subst =

--- a/YaML/lib/inferencer.ml
+++ b/YaML/lib/inferencer.ml
@@ -467,7 +467,6 @@ let infer (stms : Ast.statements) (check_mode : occurs_check_mode)
   : (Typedtree.tbinding list, error) result
   =
   mode := check_mode;
-  (* :) *)
   infer_statements stms
 ;;
 

--- a/YaML/lib/inferencer.mli
+++ b/YaML/lib/inferencer.mli
@@ -12,5 +12,5 @@ type error =
 (** Pretty printer for errors *)
 val pp_error : Format.formatter -> error -> unit
 
-(** Infer type of expession *)
-val infer_expr : Ast.expr -> (Typetree.ty * Typedtree.texpr, error) result
+(** Infer type of statements *)
+val infer : Ast.statements -> (Typedtree.tbinding list, error) result

--- a/YaML/lib/inferencer.mli
+++ b/YaML/lib/inferencer.mli
@@ -9,8 +9,12 @@ type error =
   | `Unification_failed of Typetree.ty * Typetree.ty
   ]
 
+type occurs_check_mode =
+  | Enable
+  | Disable
+
 (** Pretty printer for errors *)
 val pp_error : Format.formatter -> error -> unit
 
 (** Infer type of statements *)
-val infer : Ast.statements -> (Typedtree.tbinding list, error) result
+val infer : Ast.statements -> occurs_check_mode -> (Typedtree.tbinding list, error) result

--- a/YaML/lib/typedtree.ml
+++ b/YaML/lib/typedtree.ml
@@ -23,12 +23,12 @@ type texpr =
   | TFun of arg * texpr * ty (** Typed expression for function *)
 
 (** Typed binding type *)
-type tbindings =
+type tbinding =
   | TLet of string * texpr * ty (** Typed expression for let declaration *)
   | TLetRec of string * texpr * ty (** Typed expression for let rec declaration *)
 
 (** Typed statements type *)
-type tstatements = tbindings list
+type tstatements = tbinding list
 
 (** Typed texpr constructors *)
 
@@ -41,7 +41,7 @@ let tletin s a b t = TLetIn (s, a, b, t)
 let tletrecin s a b t = TLetRecIn (s, a, b, t)
 let tfun arg_name arg_type a t = TFun (Arg (arg_name, arg_type), a, t)
 
-(** tbindings constructors *)
+(** tbinding constructors *)
 
 let slet n e t = TLet (n, e, t)
 let sletrec n e t = TLetRec (n, e, t)

--- a/YaML/lib/typedtree.ml
+++ b/YaML/lib/typedtree.ml
@@ -43,5 +43,5 @@ let tfun arg_name arg_type a t = TFun (Arg (arg_name, arg_type), a, t)
 
 (** tbinding constructors *)
 
-let slet n e t = TLet (n, e, t)
-let sletrec n e t = TLetRec (n, e, t)
+let tlet n e t = TLet (n, e, t)
+let tletrec n e t = TLetRec (n, e, t)

--- a/YaML/lib/typedtree.ml
+++ b/YaML/lib/typedtree.ml
@@ -15,21 +15,33 @@ type texpr =
   (** Typed expression for the binary operations *)
   | TApp of texpr * texpr * ty
   (** Typed expression for the function application to the arguments *)
-  | TIfThenElse of texpr * texpr * texpr (** Typed expression for condition statement *)
-  | TLet of string * texpr * ty (** Typed expression for let declaration *)
-  | TLetRec of string * texpr * ty (** Typed expression for let rec declaration*)
+  | TIfThenElse of texpr * texpr * texpr * ty
+  (** Typed expression for condition statement *)
   | TLetIn of string * texpr * texpr * ty (** Typed expression for let in declaration *)
   | TLetRecIn of string * texpr * texpr * ty
   (** Typed expression for let rec in declaration *)
   | TFun of arg * texpr * ty (** Typed expression for function *)
 
+(** Typed binding type *)
+type tbindings =
+  | TLet of string * texpr * ty (** Typed expression for let declaration *)
+  | TLetRec of string * texpr * ty (** Typed expression for let rec declaration *)
+
+(** Typed statements type *)
+type tstatements = tbindings list
+
+(** Typed texpr constructors *)
+
 let tconst c t = TConst (c, t)
 let tvar s t = TVar (s, t)
 let tbinop b e1 e2 t = TBinop (b, e1, e2, t)
 let tapp f a t = TApp (f, a, t)
-let tifthenelse i t e = TIfThenElse (i, t, e)
-let tlet s a t = TLet (s, a, t)
-let tletrec a s t = TLetRec (a, s, t)
+let tifthenelse i t e ty = TIfThenElse (i, t, e, ty)
 let tletin s a b t = TLetIn (s, a, b, t)
 let tletrecin s a b t = TLetRecIn (s, a, b, t)
 let tfun arg_name arg_type a t = TFun (Arg (arg_name, arg_type), a, t)
+
+(** tbindings constructors *)
+
+let slet n e t = TLet (n, e, t)
+let sletrec n e t = TLetRec (n, e, t)

--- a/YaML/lib/typedtree.mli
+++ b/YaML/lib/typedtree.mli
@@ -2,36 +2,47 @@
 
 (** SPDX-License-Identifier: LGPL-2.1-or-later *)
 
-open Typetree
 open Ast
 
-type arg = Arg of string * ty (** Typed function argument *)
+type arg = Arg of string * Typetree.ty (** Typed function argument *)
 
 (** Typed expession type *)
 type texpr =
-  | TConst of const * ty (** Typed expression for the constant *)
-  | TVar of string * ty (** Typed expression for the variables *)
-  | TBinop of bin_op * texpr * texpr * ty
+  | TConst of const * Typetree.ty (** Typed expression for the constant *)
+  | TVar of string * Typetree.ty (** Typed expression for the variables *)
+  | TBinop of bin_op * texpr * texpr * Typetree.ty
   (** Typed expression for the binary operations *)
-  | TApp of texpr * texpr * ty
+  | TApp of texpr * texpr * Typetree.ty
   (** Typed expression for the function application to the arguments *)
-  | TIfThenElse of texpr * texpr * texpr (** Typed expression for condition statement *)
-  | TLet of string * texpr * ty (** Typed expression for let declaration *)
-  | TLetRec of string * texpr * ty (** Typed expression for let rec declaration*)
-  | TLetIn of string * texpr * texpr * ty (** Typed expression for let in declaration *)
-  | TLetRecIn of string * texpr * texpr * ty
+  | TIfThenElse of texpr * texpr * texpr * Typetree.ty
+  (** Typed expression for condition statement *)
+  | TLetIn of string * texpr * texpr * Typetree.ty
+  (** Typed expression for let in declaration *)
+  | TLetRecIn of string * texpr * texpr * Typetree.ty
   (** Typed expression for let rec in declaration *)
-  | TFun of arg * texpr * ty (** Typed expression for function *)
+  | TFun of arg * texpr * Typetree.ty (** Typed expression for function *)
 
-(* Constructors for typed expressions *)
+(** Typed binding type *)
+type tbindings =
+  | TLet of string * texpr * Typetree.ty (** Typed expression for let declaration *)
+  | TLetRec of string * texpr * Typetree.ty
+  (** Typed expression for let rec declaration *)
+
+(** Typed statements type *)
+type tstatements = tbindings list
+
+(** Constructors for typed expressions *)
 
 val tconst : Ast.const -> Typetree.ty -> texpr
 val tvar : string -> Typetree.ty -> texpr
 val tbinop : Ast.bin_op -> texpr -> texpr -> Typetree.ty -> texpr
 val tapp : texpr -> texpr -> Typetree.ty -> texpr
-val tifthenelse : texpr -> texpr -> texpr -> texpr
-val tlet : string -> texpr -> Typetree.ty -> texpr
-val tletrec : string -> texpr -> Typetree.ty -> texpr
+val tifthenelse : texpr -> texpr -> texpr -> Typetree.ty -> texpr
 val tletin : string -> texpr -> texpr -> Typetree.ty -> texpr
 val tletrecin : string -> texpr -> texpr -> Typetree.ty -> texpr
 val tfun : string -> Typetree.ty -> texpr -> Typetree.ty -> texpr
+
+(** tbindings constructors *)
+
+val tlet : string -> texpr -> Typetree.ty -> tbindings
+val tletrec : string -> texpr -> Typetree.ty -> tbindings

--- a/YaML/lib/typedtree.mli
+++ b/YaML/lib/typedtree.mli
@@ -23,13 +23,13 @@ type texpr =
   | TFun of arg * texpr * Typetree.ty (** Typed expression for function *)
 
 (** Typed binding type *)
-type tbindings =
+type tbinding =
   | TLet of string * texpr * Typetree.ty (** Typed expression for let declaration *)
   | TLetRec of string * texpr * Typetree.ty
   (** Typed expression for let rec declaration *)
 
 (** Typed statements type *)
-type tstatements = tbindings list
+type tstatements = tbinding list
 
 (** Constructors for typed expressions *)
 
@@ -44,5 +44,5 @@ val tfun : string -> Typetree.ty -> texpr -> Typetree.ty -> texpr
 
 (** tbindings constructors *)
 
-val tlet : string -> texpr -> Typetree.ty -> tbindings
-val tletrec : string -> texpr -> Typetree.ty -> tbindings
+val tlet : string -> texpr -> Typetree.ty -> tbinding
+val tletrec : string -> texpr -> Typetree.ty -> tbinding

--- a/YaML/tests/combinators.ya
+++ b/YaML/tests/combinators.ya
@@ -1,0 +1,2 @@
+let rec fix_y f = f (fix_y f)
+let rec fix_z f x = f (fix_z f) x

--- a/YaML/tests/factorial.ya
+++ b/YaML/tests/factorial.ya
@@ -9,10 +9,10 @@ let fac_tailrec n =
 let fac_tailrec5 = fac_tailrec 5
 
 let fact_cps n =
-  let rec hellper acc count k =
+  let rec helper acc count k =
     if count = n then k acc
-    else hellper (acc * (count + 1)) (count + 1) k
+    else helper (acc * (count + 1)) (count + 1) k
   in
-  hellper 1 0 (fun x -> x)
+  helper 1 0 (fun x -> x)
 
 let fact_cps10 = fact_cps 10

--- a/YaML/tests/factorial.ya
+++ b/YaML/tests/factorial.ya
@@ -1,0 +1,18 @@
+let rec fac n = if n = 1 then 1 else n * fac (n - 1)
+
+let fac10 = fac 10
+
+let fac_tailrec n =
+  let rec fact n acc = if n < 1 then acc else fact (n - 1) (acc * n) in
+  fact n 1
+
+let fac_tailrec5 = fac_tailrec 5
+
+let fact_cps n =
+  let rec hellper acc count k =
+    if count = n then k acc
+    else hellper (acc * (count + 1)) (count + 1) k
+  in
+  hellper 1 0 (fun x -> x)
+
+let fact_cps10 = fact_cps 10

--- a/YaML/tests/factorial.ya
+++ b/YaML/tests/factorial.ya
@@ -16,3 +16,17 @@ let fact_cps n =
   helper 1 0 (fun x -> x)
 
 let fact_cps10 = fact_cps 10
+
+let rec fix_y f = f (fix_y f)
+
+let fac_open self n = if n <= 1 then 1 else n * (self (n - 1))
+
+let fix_y_fac = fix_y fac_open
+
+let fix_y_fac5 = fix_y_fac 5
+
+let rec fix_z f x = f (fix_z f) x
+
+let fix_z_fac = fix_z fac_open
+
+let fix_z_fac5 = fix_z_fac 5

--- a/YaML/tests/factorial.ya
+++ b/YaML/tests/factorial.ya
@@ -1,4 +1,4 @@
-let rec fac n = if n = 1 then 1 else n * fac (n - 1)
+let rec fac n = if n <= 1 then 1 else n * fac (n - 1)
 
 let fac10 = fac 10
 
@@ -8,25 +8,13 @@ let fac_tailrec n =
 
 let fac_tailrec5 = fac_tailrec 5
 
-let fact_cps n =
-  let rec helper acc count k =
-    if count = n then k acc
-    else helper (acc * (count + 1)) (count + 1) k
-  in
-  helper 1 0 (fun x -> x)
-
-let fact_cps10 = fact_cps 10
-
 let rec fix_y f = f (fix_y f)
+let rec fix_z f x = f (fix_z f) x
 
 let fac_open self n = if n <= 1 then 1 else n * (self (n - 1))
 
 let fix_y_fac = fix_y fac_open
-
-let fix_y_fac5 = fix_y_fac 5
-
-let rec fix_z f x = f (fix_z f) x
-
 let fix_z_fac = fix_z fac_open
 
+let fix_y_fac5 = fix_y_fac 5
 let fix_z_fac5 = fix_z_fac 5

--- a/YaML/tests/fibonacci.ya
+++ b/YaML/tests/fibonacci.ya
@@ -1,0 +1,30 @@
+let rec fib n =
+    if n < 3 then 1 else fib (n - 1) + fib (n - 2)
+
+let fib10 = fib 10
+
+let fib n =
+    let rec helper n =
+        if n < 3 then 1 else helper (n - 1) + helper (n - 2)
+    in
+    helper n
+
+let fib5 = fib 5
+
+let fib_tailrec n =
+  let rec helper a b count =
+    if count = n then a
+    else helper b (a + b) (count + 1)
+  in
+  helper 0 1 0
+
+let fib10 = fib_tailrec 10
+
+let fib_cps n =
+  let rec helper a b count k =
+    if count = n then k a
+    else helper b (a + b) (count + 1) k
+  in
+  helper 0 1 0 (fun x -> x)
+
+let fib_cps10 = fib_cps 10

--- a/YaML/tests/fibonacci.ya
+++ b/YaML/tests/fibonacci.ya
@@ -28,3 +28,14 @@ let fib_cps n =
   helper 0 1 0 (fun x -> x)
 
 let fib_cps10 = fib_cps 10
+
+let rec fix_y f = f (fix_y f)
+let rec fix_z f x = f (fix_z f) x
+
+let fib_open self n = if n < 3 then 1 else self (n - 1) + self (n - 2)
+
+let fib_y = fix_y fib_open
+let fib_z = fix_z fib_open
+
+let fib_y5 = fib_y 5
+let fib_z5 = fib_z 5

--- a/YaML/tests/fibonacci.ya
+++ b/YaML/tests/fibonacci.ya
@@ -3,29 +3,22 @@ let rec fib n =
 
 let fib10 = fib 10
 
-let fib n =
-    let rec helper n =
-        if n < 3 then 1 else helper (n - 1) + helper (n - 2)
-    in
-    helper n
-
-let fib5 = fib 5
-
 let fib_tailrec n =
   let rec helper a b count =
     if count = n then a
     else helper b (a + b) (count + 1)
   in
-  helper 0 1 0
+  if n <= 0 then 0 else helper 0 1
 
 let fib10 = fib_tailrec 10
 
 let fib_cps n =
-  let rec helper a b count k =
-    if count = n then k a
-    else helper b (a + b) (count + 1) k
+  let rec helper n cont =
+    if n < 3
+    then cont 1
+    else cont (helper (n - 1) (fun x -> helper (n - 2) (fun y -> x + y)))
   in
-  helper 0 1 0 (fun x -> x)
+  helper n (fun x -> x)
 
 let fib_cps10 = fib_cps 10
 

--- a/YaML/tests/fibonacci.ya
+++ b/YaML/tests/fibonacci.ya
@@ -4,11 +4,9 @@ let rec fib n =
 let fib10 = fib 10
 
 let fib_tailrec n =
-  let rec helper a b count =
-    if count = n then a
-    else helper b (a + b) (count + 1)
-  in
-  if n <= 0 then 0 else helper 0 1
+  let rec helper n a b = if n <= 1 then a else helper (n - 1) b (a + b) in
+  helper n 0 1
+;;
 
 let fib10 = fib_tailrec 10
 

--- a/YaML/tests/occurs-check-disable.ya
+++ b/YaML/tests/occurs-check-disable.ya
@@ -1,0 +1,10 @@
+let fix f = (fun x -> f (x x)) (fun y -> f (y y))
+
+let fac_open self n = if n <= 1 then 1 else n * (self (n - 1))
+let fib_open self n = if n < 3 then 1 else self (n - 1) + self (n - 2)
+
+let fac = fix fac_open
+let fib = fix fib_open
+
+let fac5 = fac 5
+let fib5 = fib 6

--- a/YaML/yaml-inference.t
+++ b/YaML/yaml-inference.t
@@ -6,6 +6,10 @@ Show help
     -f Read program from specified file, not from the stdin.
     -help  Display this list of options
     --help  Display this list of options
+Fixed point combinators
+  $ ./yaml.exe -i -f ./tests/combinators.ya
+  fix_y: (('a -> 'a) -> 'a)
+  fix_z: ((('a -> 'b) -> ('a -> 'b)) -> ('a -> 'b))
 Factorial
   $ ./yaml.exe -i -f ./tests/factorial.ya
   fac: (int -> int)
@@ -14,6 +18,13 @@ Factorial
   fac_tailrec5: int
   fact_cps: (int -> int)
   fact_cps10: int
+  fix_y: (('a -> 'a) -> 'a)
+  fac_open: ((int -> int) -> (int -> int))
+  fix_y_fac: (int -> int)
+  fix_y_fac5: int
+  fix_z: ((('a -> 'b) -> ('a -> 'b)) -> ('a -> 'b))
+  fix_z_fac: (int -> int)
+  fix_z_fac5: int
 Fibonacci
   $ ./yaml.exe -i -f ./tests/fibonacci.ya
   fib: (int -> int)
@@ -24,3 +35,10 @@ Fibonacci
   fib10: int
   fib_cps: (int -> int)
   fib_cps10: int
+  fix_y: (('a -> 'a) -> 'a)
+  fix_z: ((('a -> 'b) -> ('a -> 'b)) -> ('a -> 'b))
+  fib_open: ((int -> int) -> (int -> int))
+  fib_y: (int -> int)
+  fib_z: (int -> int)
+  fib_y5: int
+  fib_z5: int

--- a/YaML/yaml-inference.t
+++ b/YaML/yaml-inference.t
@@ -42,3 +42,5 @@ Fibonacci
   fib_z: (int -> int)
   fib_y5: int
   fib_z5: int
+Occurs check is disabled
+  $ ./yaml.exe -i -d -f ./tests/occurs-check-disable.ya

--- a/YaML/yaml-inference.t
+++ b/YaML/yaml-inference.t
@@ -17,32 +17,16 @@ Factorial
   fac10: int
   fac_tailrec: (int -> int)
   fac_tailrec5: int
-  fact_cps: (int -> int)
-  fact_cps10: int
   fix_y: (('a -> 'a) -> 'a)
+  fix_z: ((('a -> 'b) -> ('a -> 'b)) -> ('a -> 'b))
   fac_open: ((int -> int) -> (int -> int))
   fix_y_fac: (int -> int)
-  fix_y_fac5: int
-  fix_z: ((('a -> 'b) -> ('a -> 'b)) -> ('a -> 'b))
   fix_z_fac: (int -> int)
+  fix_y_fac5: int
   fix_z_fac5: int
 Fibonacci
   $ ./yaml.exe -i -f ./tests/fibonacci.ya
-  fib: (int -> int)
-  fib10: int
-  fib: (int -> int)
-  fib5: int
-  fib_tailrec: (int -> int)
-  fib10: int
-  fib_cps: (int -> int)
-  fib_cps10: int
-  fix_y: (('a -> 'a) -> 'a)
-  fix_z: ((('a -> 'b) -> ('a -> 'b)) -> ('a -> 'b))
-  fib_open: ((int -> int) -> (int -> int))
-  fib_y: (int -> int)
-  fib_z: (int -> int)
-  fib_y5: int
-  fib_z5: int
+  Typechecker error: unification failed on int and (int -> int)
 Occurs check is disabled
   $ ./yaml.exe -i -d -f ./tests/occurs-check-disable.ya
   fix: (('a -> 'a) -> 'a)

--- a/YaML/yaml-inference.t
+++ b/YaML/yaml-inference.t
@@ -1,0 +1,26 @@
+Show help
+  $ ./yaml.exe -help
+  yaml -i -f <file>
+  Compile program from stdin
+    -i Infer only the types for the input, do not use the compiler.
+    -f Read program from specified file, not from the stdin.
+    -help  Display this list of options
+    --help  Display this list of options
+Factorial
+  $ ./yaml.exe -i -f ./tests/factorial.ya
+  fac: (int -> int)
+  fac10: int
+  fac_tailrec: (int -> int)
+  fac_tailrec5: int
+  fact_cps: (int -> int)
+  fact_cps10: int
+Fibonacci
+  $ ./yaml.exe -i -f ./tests/fibonacci.ya
+  fib: (int -> int)
+  fib10: int
+  fib: (int -> int)
+  fib5: int
+  fib_tailrec: (int -> int)
+  fib10: int
+  fib_cps: (int -> int)
+  fib_cps10: int

--- a/YaML/yaml-inference.t
+++ b/YaML/yaml-inference.t
@@ -1,9 +1,10 @@
 Show help
   $ ./yaml.exe -help
-  yaml -i -f <file>
+  yaml -i -d -f <file>
   Compile program from stdin
     -i Infer only the types for the input, do not use the compiler.
     -f Read program from specified file, not from the stdin.
+    -d Disable occurrence checking during type checking
     -help  Display this list of options
     --help  Display this list of options
 Fixed point combinators
@@ -44,3 +45,10 @@ Fibonacci
   fib_z5: int
 Occurs check is disabled
   $ ./yaml.exe -i -d -f ./tests/occurs-check-disable.ya
+  fix: (('a -> 'a) -> 'a)
+  fac_open: ((int -> int) -> (int -> int))
+  fib_open: ((int -> int) -> (int -> int))
+  fac: (int -> int)
+  fib: (int -> int)
+  fac5: int
+  fib5: int

--- a/YaML/yaml-inference.t
+++ b/YaML/yaml-inference.t
@@ -26,7 +26,19 @@ Factorial
   fix_z_fac5: int
 Fibonacci
   $ ./yaml.exe -i -f ./tests/fibonacci.ya
-  Typechecker error: unification failed on int and (int -> int)
+  fib: (int -> int)
+  fib10: int
+  fib_tailrec: (int -> int)
+  fib10: int
+  fib_cps: (int -> int)
+  fib_cps10: int
+  fix_y: (('a -> 'a) -> 'a)
+  fix_z: ((('a -> 'b) -> ('a -> 'b)) -> ('a -> 'b))
+  fib_open: ((int -> int) -> (int -> int))
+  fib_y: (int -> int)
+  fib_z: (int -> int)
+  fib_y5: int
+  fib_z5: int
 Occurs check is disabled
   $ ./yaml.exe -i -d -f ./tests/occurs-check-disable.ya
   fix: (('a -> 'a) -> 'a)

--- a/YaML/yaml.ml
+++ b/YaML/yaml.ml
@@ -42,7 +42,7 @@ let read_whole_file filename = In_channel.with_open_bin filename In_channel.inpu
 let () =
   match YamlCLIArgs.parse () with
   | { YamlCLIArgs.infer_type; filename } when infer_type && filename == "" ->
-    let input = read_line () in
+    let input = In_channel.input_all In_channel.stdin in
     infer_types input
   | { YamlCLIArgs.infer_type; filename } when infer_type && filename != "" ->
     if Sys.file_exists filename

--- a/YaML/yaml.ml
+++ b/YaML/yaml.ml
@@ -1,0 +1,54 @@
+open Yaml_lib
+open Format
+
+module YamlCLIArgs = struct
+  type t =
+    { infer_type : bool
+    ; filename : string
+    }
+
+  let usage = "yaml [-i <only-infer-type>] [-f <file>]\nCompile program from stdin"
+
+  let parse () =
+    let infer = ref false in
+    let file = ref "" in
+    let specs =
+      [ ( "-i"
+        , Arg.Set infer
+        , "Infer only the types for the input, do not use the compiler." )
+      ; "-f", Set_string file, "Read program from specified file, not from the stdin."
+      ]
+    in
+    let anon _ = () in
+    Arg.parse specs anon usage;
+    { infer_type = !infer; filename = !file }
+  ;;
+end
+
+let pp_statements = Pprinttypedtree.pp_statements "\n" Pprinttypedtree.Brief
+
+let infer_types input =
+  let parsed = Parser.parse input in
+  match parsed with
+  | Ok statements ->
+    (match Inferencer.infer statements with
+     | Ok typed_statements -> printf "%a!" pp_statements typed_statements
+     | Error err -> printf "%a!" Inferencer.pp_error err)
+  | Error err -> printf "%a!" Parser.pp_error err
+;;
+
+let read_whole_file filename = In_channel.with_open_bin filename In_channel.input_all
+
+let () =
+  match YamlCLIArgs.parse () with
+  | { YamlCLIArgs.infer_type; filename } when infer_type && filename == "" ->
+    let input = read_line () in
+    infer_types input
+  | { YamlCLIArgs.infer_type; filename } when infer_type && filename != "" ->
+    if Sys.file_exists filename
+    then (
+      let input = read_whole_file filename in
+      infer_types input)
+    else printf "File %s does not exist" filename
+  | _ -> printf "Сompilation is not currently implemented"
+;;

--- a/YaML/yaml.ml
+++ b/YaML/yaml.ml
@@ -1,3 +1,7 @@
+(** Copyright 2023-2024, Ilya Pankratov, Maxim Drumov *)
+
+(** SPDX-License-Identifier: LGPL-2.1-or-later *)
+
 open Yaml_lib
 open Format
 open Result

--- a/YaML/yaml.ml
+++ b/YaML/yaml.ml
@@ -25,7 +25,7 @@ module YamlCLIArgs = struct
     in
     let anon _ = () in
     Arg.parse specs anon usage;
-    { infer_type = !infer; filename = !file; occurs_check = !occurs_check_flag }
+    { infer_type = !infer; filename = !file; occurs_check = not !occurs_check_flag }
   ;;
 end
 


### PR DESCRIPTION
Этот пул реквест должен быть смёрджен после того, как будет смёрджен #4, так как данный пул реквест опирается на изменения сделанные в #4.

1) Улучшил вывод типов, пофиксив ошибку, возникующую при выводе типа конструкции let rec
2) Изменил pretty принтеры в соответсвии с новыми ast
3) Изменил вывод типов в соответствии с новым ast
4) Добавил возможность включения (выключения) occurs check, используя мутабельную переменную :)
5) Добавил всевозможные cram тесты для вывода типов фибоначи, факториала, комбинаторов неподвижной точки
6) Сделал исполняемый файл, позволяющий запускать компилятор